### PR TITLE
chore: add direnv paths to .gitignore

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 .env
+.direnv
+.envrc


### PR DESCRIPTION
we should add .envrc to .gitignore because people might have different setups for their .envrc and / or might want to pass options to nix in .envrc